### PR TITLE
Optimize display effect when content of log table cell exceed max cha…

### DIFF
--- a/ui/log/src/main/kotlin/me/gegenbauer/catspy/log/ui/table/TextPaneRendererProvider.kt
+++ b/ui/log/src/main/kotlin/me/gegenbauer/catspy/log/ui/table/TextPaneRendererProvider.kt
@@ -1,6 +1,7 @@
 package me.gegenbauer.catspy.log.ui.table
 
 import me.gegenbauer.catspy.configuration.SettingsManager
+import me.gegenbauer.catspy.java.ext.maxLength
 import me.gegenbauer.catspy.log.filter.DefaultLogFilter
 import me.gegenbauer.catspy.log.metadata.Column
 import me.gegenbauer.catspy.log.metadata.LogMetadata
@@ -132,7 +133,8 @@ class TextPaneRendererProvider : BaseLogCellRendererProvider() {
             val logFilter = table.tableModel.getLogFilter()
             if (logFilter !is DefaultLogFilter) return content
             if (filterIndex >= logFilter.filters.size) return content
-            return content.take(logFilter.filters[filterIndex].column.uiConf.column.charLen)
+            val maxLength = logFilter.filters[filterIndex].column.uiConf.column.charLen
+            return content.maxLength(maxLength)
         }
     }
 


### PR DESCRIPTION
Optimize display effect when content of log table cell exceed max char length(defined in Log Customization). Use ellipsis to indicate content is truncated