### PR TITLE
Add support to read first file of zip files.

### DIFF
--- a/buildSrc/src/main/kotlin/VersionManagement.kt
+++ b/buildSrc/src/main/kotlin/VersionManagement.kt
@@ -123,6 +123,7 @@ object Squareup {
 
     val okhttp = Dependency(groupName, "okhttp", version)
     val okhttpLoggingInterceptor = Dependency(groupName, "logging-interceptor", version)
+    val okio = Dependency("com.squareup.okio", "okio", "3.9.1")
 }
 
 object MigLayout {

--- a/ui/log/build.gradle.kts
+++ b/ui/log/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(projects.javaext)
     implementation(projects.ui.render)
     implementation(projects.ui.databinding)
+    implementation(Squareup.okio)
 
     testImplementation(kotlinTestApi())
 }


### PR DESCRIPTION
Add support to read first file of zip files.

While not perfect for zip files with multiple files, this is still better than current solution that tries to parse the binary zip, and solve the normal use case of a single log file in a single zip file.