### PR TITLE
Fix the issue where spaces in the content copied from the Log Detail Dialog are replaced with &nbsp;, causing text matching failures...

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ kotlin.code.style=official
 # Application Global Properties
 app.name=CatSpy
 app.id=me.gegenbauer.catspy
-app.version.name=1.1.7
-app.version.code=1001007
+app.version.name=1.1.8
+app.version.code=1001008
 app.author=gegenbauer
 app.repo=catspy
 app.repo.link=https://github.com/Gegenbauer/CatSpy

--- a/ui/log/src/main/kotlin/me/gegenbauer/catspy/log/ui/customize/ColumnsEditPanel.kt
+++ b/ui/log/src/main/kotlin/me/gegenbauer/catspy/log/ui/customize/ColumnsEditPanel.kt
@@ -198,6 +198,9 @@ class ColumnsEditPanel : BaseEditableTablePanel<ColumnModel>() {
     private fun isNameAlreadyUsed(name: String): Boolean {
         val model = table.model as DefaultTableModel
         for (i in 0 until model.rowCount) {
+            if (i == table.selectedRow) {
+                continue
+            }
             if (model.getValueAt(i, COLUMN_NAME_INDEX) == name) {
                 return true
             }

--- a/ui/log/src/main/kotlin/me/gegenbauer/catspy/log/ui/customize/FiltersEditPanel.kt
+++ b/ui/log/src/main/kotlin/me/gegenbauer/catspy/log/ui/customize/FiltersEditPanel.kt
@@ -219,6 +219,9 @@ class FiltersEditPanel : BaseEditableTablePanel<ColumnModel.FilterUIConf>() {
     private fun isNameAlreadyUsed(name: String): Boolean {
         val model = table.model as DefaultTableModel
         for (i in 0 until model.rowCount) {
+            if (i == table.selectedRow) {
+                continue
+            }
             if (model.getValueAt(i, COLUMN_INDEX_NAME) == name) {
                 return true
             }

--- a/ui/log/src/main/kotlin/me/gegenbauer/catspy/log/ui/tab/FileLogGuidancePanel.kt
+++ b/ui/log/src/main/kotlin/me/gegenbauer/catspy/log/ui/tab/FileLogGuidancePanel.kt
@@ -29,6 +29,7 @@ import java.io.File
 import java.text.SimpleDateFormat
 import java.util.*
 import javax.swing.BorderFactory
+import javax.swing.JFrame
 import javax.swing.JOptionPane
 import javax.swing.JPanel
 import javax.swing.JScrollPane
@@ -137,8 +138,9 @@ class FileLogGuidancePanel(
 
         private fun showFileNotExistsWarning(file: RecentFile) {
             val message = STRINGS.ui.fileNotExistWarning.get(file.path)
+            val frame = findFrameFromParent<JFrame>()
             JOptionPane.showMessageDialog(
-                this,
+                frame,
                 message,
                 EMPTY_STRING,
                 JOptionPane.WARNING_MESSAGE

--- a/ui/log/src/main/kotlin/me/gegenbauer/catspy/log/ui/table/TextPaneRendererProvider.kt
+++ b/ui/log/src/main/kotlin/me/gegenbauer/catspy/log/ui/table/TextPaneRendererProvider.kt
@@ -38,19 +38,35 @@ class TextPaneRendererProvider : BaseLogCellRendererProvider() {
     }
 
     override suspend fun buildDetailRendererComponent(logTable: LogTable, rows: List<Int>): JTextComponent {
-        fun renderLogFilter(renderer: StringRenderer, logFilterItem: FilterItem, content: String) {
+        fun renderLogFilter(renderer: StringRenderer, logFilterItem: FilterItem, content: String, offset: Int) {
             val matchedList = logFilterItem.getMatchedList(content)
             matchedList.forEach {
-                renderer.highlight(it.first, it.second, logMetadata.colorScheme.filterContentBackground)
-                renderer.foreground(it.first, it.second, logMetadata.colorScheme.filterContentForeground)
+                renderer.highlight(
+                    it.first + offset,
+                    it.second + offset,
+                    logMetadata.colorScheme.filterContentBackground
+                )
+                renderer.foreground(
+                    it.first + offset,
+                    it.second + offset,
+                    logMetadata.colorScheme.filterContentForeground
+                )
             }
         }
 
-        fun renderSearchFilter(renderer: StringRenderer, searchFilterItem: FilterItem, content: String) {
+        fun renderSearchFilter(renderer: StringRenderer, searchFilterItem: FilterItem, content: String, offset: Int) {
             val matchedList = searchFilterItem.getMatchedList(content)
             matchedList.forEach {
-                renderer.highlight(it.first, it.second, logMetadata.colorScheme.searchContentBackground)
-                renderer.foreground(it.first, it.second, logMetadata.colorScheme.searchContentForeground)
+                renderer.highlight(
+                    it.first + offset,
+                    it.second + offset,
+                    logMetadata.colorScheme.searchContentBackground
+                )
+                renderer.foreground(
+                    it.first + offset,
+                    it.second + offset,
+                    logMetadata.colorScheme.searchContentForeground
+                )
             }
         }
 
@@ -73,8 +89,8 @@ class TextPaneRendererProvider : BaseLogCellRendererProvider() {
                     it.highlight(offset, offset + line.length - 1, logBackground)
                     val foreground = getLevel(logItem).logForeground
                     it.foreground(offset, offset + line.length - 1, foreground)
-                    logFilterItems.forEach { filterItem -> renderLogFilter(it, filterItem, line) }
-                    renderSearchFilter(it, searchFilterItem, line)
+                    logFilterItems.forEach { filterItem -> renderLogFilter(it, filterItem, line, offset) }
+                    renderSearchFilter(it, searchFilterItem, line, offset)
                     offset += line.length + 1
                 }
                 it.updateRaw(content)


### PR DESCRIPTION
Fix the issue where Log Detail Dialog shows content with wrong highlighted positions.
Fix the issue where the name of column or filter is unable to be modified.
Fix the issue where spaces in the content copied from the Log Detail Dialog are replaced with &nbsp;, causing text matching failures.